### PR TITLE
set cursor position to before the file extension

### DIFF
--- a/Rename.lua
+++ b/Rename.lua
@@ -39,6 +39,7 @@ mp.add_key_binding("F2", "rename-file", function()
         text = "Enter new filename:",
         default_input = filename,
         replace = false,
+        cursor_pos = filename:find(".%w+$")
     })
 end)
 


### PR DESCRIPTION
Uses the new user-input option from https://github.com/CogentRedTester/mpv-user-input/commit/934978d6d936e8a23d53f64039fcb3c5248471ae.

As requested in https://github.com/CogentRedTester/mpv-user-input/issues/4.