### PR TITLE
Prevent Playing New File on Rename Failure

### DIFF
--- a/Rename.lua
+++ b/Rename.lua
@@ -16,8 +16,12 @@ local function rename(text, error)
     local newfilepath = directory..text
 
     msg.info( string.format("renaming '%s.%s' to '%s'", name, extension, text) )
-    local success, error = os.rename(filepath, newfilepath)
-    if not success then msg.error(error) end
+    local success, rename_error = os.rename(filepath, newfilepath)
+    if not success then
+        msg.error(rename_error)
+	mp.osd_message("rename failed")
+        return
+    end
 
     -- adding the new path to the playlist, and restarting the file with the correct path
     mp.commandv("loadfile", newfilepath, "append")


### PR DESCRIPTION
* If the renaming operation fails, the script now also shows an OSD message indicating the failure.
* Prevents playing the new file if the rename operation encounters an error.